### PR TITLE
Fix tasks controller option mapping references

### DIFF
--- a/src/Memeup.Api/Controllers/TasksController.cs
+++ b/src/Memeup.Api/Controllers/TasksController.cs
@@ -66,7 +66,7 @@ public class TasksController : ControllerBase
 
         var entity = _mapper.Map<TaskItem>(dto);
         entity.Options.Clear();
-        entity.Options.AddRange(MapOptions(dto.Options));
+        entity.Options.AddRange(TaskOptionMapping.MapOptions(dto.Options));
         _db.Tasks.Add(entity);
         await _db.SaveChangesAsync();
 
@@ -97,7 +97,7 @@ public class TasksController : ControllerBase
         entity.ExplanationText = dto.ExplanationText;
 
         entity.Options.Clear();
-        entity.Options.AddRange(MapOptions(dto.Options));
+        entity.Options.AddRange(TaskOptionMapping.MapOptions(dto.Options));
 
         await _db.SaveChangesAsync();
         return Ok(_mapper.Map<TaskDto>(entity));


### PR DESCRIPTION
## Summary
- update TasksController to call the TaskOptionMapping helper explicitly when building task options

## Testing
- `dotnet publish` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d97346ace4832f8168ba57e58b4826