### PR TITLE
Handle missing task option IDs when updating tasks

### DIFF
--- a/src/Memeup.Api/Data/MemeupDbContext.cs
+++ b/src/Memeup.Api/Data/MemeupDbContext.cs
@@ -29,8 +29,8 @@ public class MemeupDbContext : IdentityDbContext<ApplicationUser, IdentityRole<G
 
             opt.WithOwner().HasForeignKey("TaskItemId");
 
-            opt.HasKey("Id");
-            opt.Property<Guid>("Id")
+            opt.HasKey(o => o.Id);
+            opt.Property(o => o.Id)
                 .ValueGeneratedOnAdd();
 
             opt.Property(o => o.Label)
@@ -59,36 +59,36 @@ public class MemeupDbContext : IdentityDbContext<ApplicationUser, IdentityRole<G
     }
 
     private void TouchTimestamps()
-{
-    var now = DateTimeOffset.UtcNow;
-
-    foreach (var entry in ChangeTracker.Entries())
     {
-        if (entry.State is not (EntityState.Added or EntityState.Modified))
-            continue;
+        var now = DateTimeOffset.UtcNow;
 
-        // Есть ли у сущности поле UpdatedAt?
-        var hasUpdatedAt = entry.Metadata.FindProperty("UpdatedAt") is not null;
-        if (hasUpdatedAt)
+        foreach (var entry in ChangeTracker.Entries())
         {
-            entry.CurrentValues["UpdatedAt"] = now;
-        }
+            if (entry.State is not (EntityState.Added or EntityState.Modified))
+                continue;
 
-        // Есть ли у сущности поле CreatedAt? (только для Added)
-        if (entry.State == EntityState.Added)
-        {
-            var hasCreatedAt = entry.Metadata.FindProperty("CreatedAt") is not null;
-            if (hasCreatedAt)
+            // Есть ли у сущности поле UpdatedAt?
+            var hasUpdatedAt = entry.Metadata.FindProperty("UpdatedAt") is not null;
+            if (hasUpdatedAt)
             {
-                entry.CurrentValues["CreatedAt"] = now;
+                entry.CurrentValues["UpdatedAt"] = now;
+            }
+
+            // Есть ли у сущности поле CreatedAt? (только для Added)
+            if (entry.State == EntityState.Added)
+            {
+                var hasCreatedAt = entry.Metadata.FindProperty("CreatedAt") is not null;
+                if (hasCreatedAt)
+                {
+                    entry.CurrentValues["CreatedAt"] = now;
+                }
+            }
+
+            var hasRowVersion = entry.Metadata.FindProperty("RowVersion") is not null;
+            if (hasRowVersion)
+            {
+                entry.CurrentValues["RowVersion"] = Guid.NewGuid().ToByteArray();
             }
         }
-
-        var hasRowVersion = entry.Metadata.FindProperty("RowVersion") is not null;
-        if (hasRowVersion)
-        {
-            entry.CurrentValues["RowVersion"] = Guid.NewGuid().ToByteArray();
-        }
     }
-}
 }

--- a/src/Memeup.Api/Domain/Tasks/TaskOption.cs
+++ b/src/Memeup.Api/Domain/Tasks/TaskOption.cs
@@ -2,7 +2,7 @@ namespace Memeup.Api.Domain.Tasks;
 
 public class TaskOption
 {
-    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid Id { get; set; }
 
     public string Label { get; set; } = string.Empty;
     public bool IsCorrect { get; set; }

--- a/src/Memeup.Api/Features/Tasks/TaskMappingProfile.cs
+++ b/src/Memeup.Api/Features/Tasks/TaskMappingProfile.cs
@@ -13,7 +13,9 @@ public class TaskMappingProfile : Profile
         CreateMap<TaskOption, TaskOptionDto>();
 
         CreateMap<TaskOptionDto, TaskOption>()
-            .ForMember(d => d.Id, m => m.MapFrom(s => s.Id ?? Guid.NewGuid()));
+            .ForMember(
+                d => d.Id,
+                m => m.MapFrom(s => s.Id is { } value && value != Guid.Empty ? value : Guid.NewGuid()));
 
         CreateMap<DomainTask, TaskDto>()
             .ForMember(d => d.Status, m => m.MapFrom(s => (int)s.Status))

--- a/tests/Memeup.Api.Tests/TasksControllerTests.cs
+++ b/tests/Memeup.Api.Tests/TasksControllerTests.cs
@@ -113,5 +113,115 @@ public class TasksControllerTests
         Assert.True(entity.Options.First().IsCorrect);
     }
 
-}
+    [Fact]
+    public async Task Update_AllowsMissingOrEmptyIdsForOptions()
+    {
+        await using var connection = new SqliteConnection("Filename=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<MemeupDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        var mapper = new MapperConfiguration(cfg => cfg.AddProfile(new TaskMappingProfile()))
+            .CreateMapper();
+
+        var section = new Section
+        {
+            Id = Guid.NewGuid(),
+            Name = "Section"
+        };
+        var level = new Level
+        {
+            Id = Guid.NewGuid(),
+            Name = "Level",
+            SectionId = section.Id,
+            Section = section
+        };
+
+        await using (var setup = new MemeupDbContext(options))
+        {
+            await setup.Database.EnsureCreatedAsync();
+            setup.Sections.Add(section);
+            setup.Levels.Add(level);
+            await setup.SaveChangesAsync();
+        }
+
+        await using var context = new MemeupDbContext(options);
+        var controller = new TasksController(context, mapper);
+
+        var createDto = new TaskCreateDto
+        {
+            LevelId = level.Id,
+            Status = 0,
+            Type = 3,
+            InternalName = "initial",
+            HeaderText = "header",
+            ImageUrl = "image",
+            Options =
+            [
+                new TaskOptionDto { Label = "Option A", IsCorrect = true },
+                new TaskOptionDto { Label = "Option B", IsCorrect = false }
+            ],
+            OrderIndex = 1,
+            TimeLimitSec = 30,
+            PointsAttempt1 = 10,
+            PointsAttempt2 = 5,
+            PointsAttempt3 = 1,
+            ExplanationText = "explanation"
+        };
+
+        var createResult = await controller.Create(createDto);
+        var created = Assert.IsType<CreatedAtActionResult>(createResult.Result);
+        var createdDto = Assert.IsType<TaskDto>(created.Value);
+
+        var existingId = createdDto.Options[0].Id;
+        Assert.NotEqual(Guid.Empty, existingId);
+
+        var updateDto = new TaskUpdateDto
+        {
+            Status = 0,
+            Type = 3,
+            InternalName = "updated",
+            HeaderText = "updated header",
+            ImageUrl = "updated-image",
+            Options =
+            [
+                new TaskOptionDto { Id = existingId, Label = "Option A updated", IsCorrect = false },
+                new TaskOptionDto { Label = "Option C", IsCorrect = true },
+                new TaskOptionDto { Id = Guid.Empty, Label = "Option D", IsCorrect = false }
+            ],
+            OrderIndex = 2,
+            TimeLimitSec = 45,
+            PointsAttempt1 = 12,
+            PointsAttempt2 = 6,
+            PointsAttempt3 = 2,
+            ExplanationText = "updated explanation"
+        };
+
+        var updateResult = await controller.Update(createdDto.Id, updateDto);
+        var ok = Assert.IsType<OkObjectResult>(updateResult.Result);
+        var updatedDto = Assert.IsType<TaskDto>(ok.Value);
+
+        Assert.Equal(3, updatedDto.Options.Length);
+        var updatedExisting = Assert.Single(updatedDto.Options.Where(o => o.Label == "Option A updated"));
+        Assert.Equal(existingId, updatedExisting.Id);
+
+        var createdOption = Assert.Single(updatedDto.Options.Where(o => o.Label == "Option C"));
+        Assert.NotEqual(Guid.Empty, createdOption.Id);
+        Assert.NotEqual(existingId, createdOption.Id);
+
+        var createdFromEmptyId = Assert.Single(updatedDto.Options.Where(o => o.Label == "Option D"));
+        Assert.NotEqual(Guid.Empty, createdFromEmptyId.Id);
+        Assert.NotEqual(existingId, createdFromEmptyId.Id);
+
+        var entity = await context.Tasks
+            .Include(t => t.Options)
+            .SingleAsync(t => t.Id == createdDto.Id);
+
+        Assert.Equal(3, entity.Options.Count);
+        Assert.Contains(entity.Options, o => o.Id == existingId && o.Label == "Option A updated");
+        Assert.Contains(entity.Options, o => o.Label == "Option C");
+        Assert.Contains(entity.Options, o => o.Label == "Option D");
+    }
 }


### PR DESCRIPTION
## Summary
- normalize incoming task option identifiers so updates handle missing or empty GUIDs
- map owned task option identifiers directly to the entity property and always generate IDs for new options
- add coverage that verifies updates succeed when some options omit identifiers

## Testing
- Not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e565cbe180832f9672fea02e73bd29